### PR TITLE
Pagination추가, MongoDb용 Encoding추가, OAuth email 추가

### DIFF
--- a/Run_Server.py
+++ b/Run_Server.py
@@ -2,6 +2,8 @@ from handling_db import MongoDB
 from handling_url import create_short_url, validate_url, normalize_url
 from flask import Flask, render_template, url_for, request, redirect, jsonify
 from flask_cors import CORS
+from data_encoder import DataEncoder
+
 app = Flask(__name__,
             static_folder='dist',
             template_folder = "./dist")
@@ -76,13 +78,18 @@ def redirect_url(short_url):
 
     return redirect(Raw_URL)
 
-@app.route('/api/test', methods=['post'])
-def test():
-    return jsonify([
-        {"id": "5846385767", "Raw_URL": "https://www.naver.com", "Short_URL": "nav2.com"},
-        {"id": "5893746588", "Raw_URL": "https://www.daum.net", "Short_URL": "dau2.net"},
-        {"id": "8284947484", "Raw_URL": "https://cloud.mongodb.com/v2/5f09fe1763fbbc6247f478b2#metrics/replicaSet/5f2504bd130d2e5f9b9e2aa0/explorer/slink/link_table/find", "Short_URL": "cloud.net"},
-        {"id": "82849473885", "Raw_URL": "https://cloud.mongodb.com/v2/5f09fe1763fbbc6247f478b2#metrics/replicaSet/5f2504bd130d2e5f9b9e2aa0/explorer/slink/link_table/find", "Short_URL": "cloud.net"}])
+@app.route('/api/linkList', methods=['POST'])
+def link_list():
+    user_id = request.json['user_id']
+    page = request.json['page']
+    item_count = request.json['item_count']
+
+    res = Mongo.get_link_pagination(user_id, page, item_count)
+    if res is None: return None
+
+    # pagination 가능하게 pagination.py 작성
+    # page, maxPage, list Dictionary로 반환하게
+    return DataEncoder().encode(res)
 
 if __name__ == "__main__":
     print(app.root_path)

--- a/data_encoder.py
+++ b/data_encoder.py
@@ -1,0 +1,12 @@
+import json
+from datetime import datetime
+from bson import ObjectId
+
+class DataEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, ObjectId):
+            return str(o)
+        elif isinstance(o, datetime):
+            return o.isoformat()
+        
+        return super().default(o)

--- a/frontend/src/components/GLoginBtn.vue
+++ b/frontend/src/components/GLoginBtn.vue
@@ -53,9 +53,10 @@ export default {
           const loggedIn = true
           const idToken = authResponse.id_token
           const name = googleUser.getBasicProfile().getName()
+          const email = googleUser.getBasicProfile().getEmail()
 
           // 유저 정보를 Vuex에 담고, Manage 페이지로 포워딩
-          this.setUserInfo({loggedIn, idToken, name})
+          this.setUserInfo({loggedIn, idToken, name, email})
           this.$router.push({name: 'Manage'})
       }.bind(this))
     }.bind(this)) 

--- a/frontend/src/components/Manage/Home/FloatingButton.vue
+++ b/frontend/src/components/Manage/Home/FloatingButton.vue
@@ -1,0 +1,1 @@
+<!-- TODO: ManageHome에 있는 FloatingButton 여기로 옮겨오기 -->

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -5,6 +5,7 @@ import MainPage from '@/views/MainPage.vue'
 import AppDrawer from '@/views/MainPage/AppDrawer.vue'
 import AppFooter from '@/views/MainPage/AppFooter.vue'
 import AppNavBar from '@/views/MainPage/AppNavBar.vue'
+import ManagePage from '@/views/ManagePage.vue'
 import ManageNavBar from '@/views/ManagePage/ManageNavBar.vue'
 import ManageNavDrawer from '@/views/ManagePage/ManageDrawer.vue'
 
@@ -16,7 +17,7 @@ const setHomePage = () => function(to, from, next) {
   if (!store.state.userInfo.loggedIn) {
     next({name: 'Main'})
   } else {
-    next({name: 'Manage'})
+    next({name: 'ManageHome'})
   }
 }
 
@@ -33,7 +34,7 @@ const loginRequired = () => function(to, from, next) {
 const logoutRequired = () => function(to, from, next) {
   console.log(store.state.userInfo)
   if (store.state.userInfo.loggedIn) {
-    next({name: 'Manage'})
+    next({name: 'ManageHome'})
   } else {
     next()
   }
@@ -69,12 +70,19 @@ const routes = [
   },
   {
     path: '/manage',
-    name: 'Manage',
+    name: 'Manage', // 이거 지워야함(지울경우 beforeEach땜에 빈화면뜸), 밑에 beforeEach도 regex로 수정해야 함
     components: {
-      default: () => import(/* webpackChunkName: "manage" */ '@/views/Manage.vue'),
+      default: ManagePage,
       navBar: ManageNavBar,
       drawer: ManageNavDrawer
     },
+    children: [
+      {
+        path: '',
+        name: 'ManageHome',
+        component: () => import(/* webpackChunkName: "manageHome" */ '@/views/ManagePage/ManageHome.vue')
+      }
+    ]
   }
   // {
   //   path: '/about',

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -12,9 +12,11 @@ export default new Vuex.Store({
     userInfo: {
       loggedIn: false,
       idToken: '',
-      name: ''
+      name: '',
+      email: ''
     },
-    serverURL: 'http://127.0.0.1:5000/ajax'
+    serverURL: 'http://127.0.0.1:5000/ajax',
+    linkPageURL: 'http://127.0.0.1:5000/api/linkList'
   },
   mutations: {
     setUserInfo(state, payload) {

--- a/frontend/src/views/ManagePage.vue
+++ b/frontend/src/views/ManagePage.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="text-left">
+    <router-view />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ManagePage'
+}
+</script>
+
+<style>
+
+</style>

--- a/handling_db.py
+++ b/handling_db.py
@@ -1,5 +1,6 @@
 from pymongo import MongoClient
 from voluptuous import Schema, Required, All, Url
+from pagination import Pagination
 
 DEFAULT_HOST = 'mongodb+srv://admin:1234@links.fc8p4.mongodb.net/PYTHON-LINK-SHORTNER?retryWrites=true&w=majority'
 DEFAULT_COL = 'link_table'
@@ -85,3 +86,14 @@ class MongoDB(MongoClient):
         result = collection.update_one(my_query, new_value)
 
         return result.modified_count > 0        # 추가되었는지 확인한다.
+
+    # user_id: 현재 로그인한 사용자 아이디
+    # page: 현재 페이지 번호
+    # item_count: 페이지 당 아이템 갯수
+    def get_link_pagination(self, user_id, page = 1, item_count = 10):
+        collection = self[self._db][self._col]
+
+        res = collection.find({ 'User_ID': user_id })
+        if res is None: return None
+
+        return Pagination.paging(res, [('Make_Date', -1)], page, item_count)

--- a/pagination.py
+++ b/pagination.py
@@ -1,0 +1,25 @@
+import math
+
+class Pagination:
+  # data는 mongodb 기본 반환값이 cursor를 넘겨준다
+  # sort_dict는 [('이름': 1 또는 -1), ('이름': 1 또는 -1)...]
+  # page는 원하는 페이지 번호
+  # item_count는 한 페이지 당 아이템 갯수
+  @staticmethod
+  def paging(data, sort_dict = None, page = 1, item_count = 10):
+    if data is None:
+      return None
+
+    # 최대 페이지 저장
+    max_page = math.ceil(data.count() / item_count)
+    # 0 ~ maxPage로 페이지 제한
+    if page < 1: page = 1
+    if page > max_page: page = max_page
+
+    # sort 옵션
+    if sort_dict is not None:
+      data.sort(sort_dict)
+    
+    data_list = list(data.skip((page - 1) * item_count).limit(item_count))
+    
+    return { 'page': page, 'maxPage': max_page, 'list': data_list }


### PR DESCRIPTION
1. OAuth email 추가
2. Pagination 도구 추가, Manage화면 Pagination하게 변경
3. Manage에 바로 컨텐츠를 띄우지 않고 ManagePage->ManageHome 형식으로 변경
4. /api/linkList에서 자신의 링크들 가져오게 추가

TODO
1. ManageHome의 FloatingButton을 컴포넌트로 변경했지만 파일만 생성하고 아직 추가안함
2. ManageHome의 Dialog들 Component로 빼놓을 예정
3. ManageHome에서 화면 크기에 따라 계정관리 버튼을 ManageDrawer로 옮기기